### PR TITLE
Fixed the HashiCorp vagrant box from Chef to Bento and added ssh-key …

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Launches 1 instance for ClusterControl and 3 instances for DB Nodes.
 
     # Download a base image from HashiCorp. 
     # If you want to use an existing or another box then change the Vagrantfile first.
-    $ vagrant box add chef/centos-7.0
+    $ vagrant box add bento/centos-7.1
     $ cd clustercontrol/centos
     $ vagrant up
 

--- a/clustercontrol/centos/Vagrantfile
+++ b/clustercontrol/centos/Vagrantfile
@@ -7,11 +7,19 @@ VAGRANTFILE_API_VERSION = "2"
 $script = <<SCRIPT
 ssh-keygen -t rsa -P '' -f ~/.ssh/id_rsa
 cat /root/.ssh/id_rsa.pub >> /root/.ssh/authorized_keys
+cp /root/.ssh/authorized_keys /vagrant/authorized_keys
 chmod 700 /root/.ssh/authorized_keys
 yum -y install wget
 wget http://severalnines.com/downloads/cmon/install-cc
 chmod +x install-cc
 S9S_CMON_PASSWORD=cmon S9S_ROOT_PASSWORD=root123 S9S_DB_PORT=3306 HOST=10.10.10.10 ./install-cc
+SCRIPT
+
+$dbscript = <<$SCRIPT
+mkdir /root/.ssh
+cp /vagrant/authorized_keys /root/.ssh/authorized_keys
+chmod 700 /root/.ssh/
+chmod 600 /root/.ssh/authorized_keys
 SCRIPT
 
 Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
@@ -34,6 +42,8 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         if cc.vm.hostname == "n1" then
             cc.vm.network :forwarded_port, guest: 80, host: (8080+n)
             cc.vm.provision "shell", inline: $script, privileged: true
+        else
+            cc.vm.provision "shell", inline: $dbscript, privileged: true
         end
     end
   end


### PR DESCRIPTION
…distribution

HashiCorp does not support the instant download of chef/centos-7.0 anymore so I updated that with their bento/centos-7.1 box.
The passwordless ssh-key distribution is done much nicer this way.
