### PR TITLE
Fixed typo Vagrantfile

### DIFF
--- a/clustercontrol/centos/Vagrantfile
+++ b/clustercontrol/centos/Vagrantfile
@@ -15,7 +15,7 @@ chmod +x install-cc
 S9S_CMON_PASSWORD=cmon S9S_ROOT_PASSWORD=root123 S9S_DB_PORT=3306 HOST=10.10.10.10 ./install-cc
 SCRIPT
 
-$dbscript = <<$SCRIPT
+$dbscript = <<SCRIPT
 mkdir /root/.ssh
 cp /vagrant/authorized_keys /root/.ssh/authorized_keys
 chmod 700 /root/.ssh/

--- a/clustercontrol/centos/Vagrantfile
+++ b/clustercontrol/centos/Vagrantfile
@@ -33,7 +33,7 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
         config.ssh.insert_key = false
         #cc.ssh.private_key_path = "<my private ssh key>"
         # change the box name if you want to use another box
-        cc.vm.box = "chef/centos-7.0"
+        cc.vm.box = "bento/centos-7.1"
         cc.vm.host_name = "n" + (1+n).to_s
         cc.vm.network :private_network, ip: "10.10.10.1" + n.to_s
         cc.vm.provider :virtualbox do |vb|


### PR DESCRIPTION
The escape string had an extra $ character.
